### PR TITLE
Support init timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ package splunk_test
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/orlangure/gnomock"
 	mocksplunk "github.com/orlangure/gnomock-splunk"
@@ -19,13 +20,13 @@ func ExampleSplunk() {
 		{
 			Event:      "action=foo",
 			Index:      "events",
-			Source:     "main",
+			Source:     "app",
 			SourceType: "http",
 		},
 		{
 			Event:      "action=bar",
 			Index:      "events",
-			Source:     "main",
+			Source:     "app",
 			SourceType: "http",
 		},
 	}
@@ -34,6 +35,7 @@ func ExampleSplunk() {
 		mocksplunk.WithLicense(true),
 		mocksplunk.WithPassword("12345678"),
 		mocksplunk.WithValues(events),
+		mocksplunk.WithInitTimeout(time.Second),
 	)
 
 	// created container now includes two events in "events" index

--- a/init.go
+++ b/init.go
@@ -2,9 +2,15 @@ package splunk
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/orlangure/gnomock"
 )
@@ -27,11 +33,12 @@ type Event struct {
 	SourceType string
 }
 
-func initf(password string, events []Event) gnomock.InitFunc {
+func initf(password string, events []Event, timeout time.Duration) gnomock.InitFunc {
 	return func(c *gnomock.Container) (err error) {
 		addr := c.Address(APIPort)
-		ensureIndex := indexRegistry(addr, password)
-		ingestEvent := postWithPassword(password)
+		post := postWithPassword(password)
+		ensureIndex := indexRegistry(post, addr)
+		ingestEvent := eventForwarder(post, addr)
 
 		for _, e := range events {
 			err := ensureIndex(e.Index)
@@ -39,29 +46,37 @@ func initf(password string, events []Event) gnomock.InitFunc {
 				return err
 			}
 
-			uri := fmt.Sprintf(
-				"https://%s/services/receivers/simple?index=%s&source=%s&sourcetype=%s",
-				addr, e.Index, e.Source, e.SourceType,
-			)
-
-			err = ingestEvent(uri, bytes.NewBufferString(e.Event))
+			err = ingestEvent(e)
 			if err != nil {
 				return err
 			}
 		}
 
-		return nil
+		timeoutChan := time.After(timeout)
+
+		for {
+			select {
+			case <-timeoutChan:
+				return context.Canceled
+			default:
+				count, err := countEvents(post, addr)
+				if err == nil && count == len(events) {
+					return nil
+				}
+
+				time.Sleep(time.Millisecond * 250)
+			}
+		}
 	}
 }
 
-func indexRegistry(addr, password string) func(string) error {
+func indexRegistry(post postFunc, addr string) func(string) error {
 	indexes := map[string]bool{"main": true}
-	post := postWithPassword(password)
 	uri := fmt.Sprintf("https://%s/services/data/indexes", addr)
 
 	return func(indexName string) error {
 		if _, ok := indexes[indexName]; !ok {
-			err := post(uri, bytes.NewBufferString("name="+indexName))
+			_, err := post(uri, bytes.NewBufferString("name="+indexName))
 			if err != nil {
 				return fmt.Errorf("can't create index: %w", err)
 			}
@@ -73,13 +88,61 @@ func indexRegistry(addr, password string) func(string) error {
 	}
 }
 
-func postWithPassword(password string) func(string, *bytes.Buffer) error {
+func eventForwarder(post postFunc, addr string) func(Event) error {
+	return func(e Event) error {
+		uri := fmt.Sprintf(
+			"https://%s/services/receivers/simple?index=%s&source=%s&sourcetype=%s",
+			addr, e.Index, e.Source, e.SourceType,
+		)
+
+		_, err := post(uri, bytes.NewBufferString(e.Event))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func countEvents(post postFunc, addr string) (int, error) {
+	uri := fmt.Sprintf("https://%s/services/search/jobs/export?output_mode=json", addr)
+	data := url.Values{}
+	data.Add("search", "search index=* | stats count")
+
+	bs, err := post(uri, bytes.NewBufferString(data.Encode()))
+	if err != nil {
+		return 0, err
+	}
+
+	var response splunkResponse
+
+	err = json.Unmarshal(bs, &response)
+	if err != nil {
+		return 0, err
+	}
+
+	countStr, ok := response.Result["count"]
+	if !ok {
+		return 0, err
+	}
+
+	count, err := strconv.Atoi(fmt.Sprintf("%s", countStr))
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+type postFunc func(string, *bytes.Buffer) ([]byte, error)
+
+func postWithPassword(password string) postFunc {
 	client := insecureClient()
 
-	return func(uri string, buf *bytes.Buffer) (err error) {
+	return func(uri string, buf *bytes.Buffer) (bs []byte, err error) {
 		req, err := http.NewRequest(http.MethodPost, uri, buf)
 		if err != nil {
-			return fmt.Errorf("can't create request: %w", err)
+			return nil, fmt.Errorf("can't create request: %w", err)
 		}
 
 		req.SetBasicAuth("admin", password)
@@ -87,7 +150,7 @@ func postWithPassword(password string) func(string, *bytes.Buffer) error {
 
 		resp, err := client.Do(req)
 		if err != nil {
-			return fmt.Errorf("request failed: %w", err)
+			return nil, fmt.Errorf("request failed: %w", err)
 		}
 
 		defer func() {
@@ -98,9 +161,18 @@ func postWithPassword(password string) func(string, *bytes.Buffer) error {
 		}()
 
 		if resp.StatusCode >= http.StatusBadRequest {
-			return errors.New(resp.Status)
+			return nil, errors.New(resp.Status)
 		}
 
-		return nil
+		bs, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("can't read response body: %w", err)
+		}
+
+		return bs, nil
 	}
+}
+
+type splunkResponse struct {
+	Result map[string]interface{} `json:"result"`
 }

--- a/options.go
+++ b/options.go
@@ -1,5 +1,9 @@
 package splunk
 
+import "time"
+
+const defaultInitTimeout = time.Second * 5
+
 // Option is an optional configuration of this Gnomock preset. Use available
 // Options to configure the container
 type Option func(*options)
@@ -31,14 +35,26 @@ func WithPassword(pass string) Option {
 	}
 }
 
+// WithInitTimeout sets the duration to wait before giving up on trying to
+// initialize this Splunk container. This option is only useful when WithValues
+// is used. Default value is 5 seconds
+func WithInitTimeout(timeout time.Duration) Option {
+	return func(o *options) {
+		o.initTimeout = timeout
+	}
+}
+
 type options struct {
 	values        []Event
 	acceptLicense bool
 	adminPassword string
+	initTimeout   time.Duration
 }
 
 func buildConfig(opts ...Option) *options {
-	config := &options{}
+	config := &options{
+		initTimeout: defaultInitTimeout,
+	}
 
 	for _, opt := range opts {
 		opt(config)

--- a/splunk.go
+++ b/splunk.go
@@ -38,6 +38,7 @@ func Preset(opts ...Option) *Splunk {
 		initialValues: config.values,
 		acceptLicense: config.acceptLicense,
 		adminPassword: config.adminPassword,
+		initTimeout:   config.initTimeout,
 	}
 
 	return s
@@ -48,6 +49,7 @@ type Splunk struct {
 	initialValues []Event
 	acceptLicense bool
 	adminPassword string
+	initTimeout   time.Duration
 }
 
 // Image returns an image that should be pulled to create this container
@@ -81,7 +83,7 @@ func (s *Splunk) Options() []gnomock.Option {
 	}
 
 	if s.initialValues != nil {
-		init := initf(s.adminPassword, s.initialValues)
+		init := initf(s.adminPassword, s.initialValues, s.initTimeout)
 		opts = append(opts, gnomock.WithInit(init))
 	}
 

--- a/splunk_test.go
+++ b/splunk_test.go
@@ -3,6 +3,7 @@ package splunk_test
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/orlangure/gnomock"
 	mocksplunk "github.com/orlangure/gnomock-splunk"
@@ -13,13 +14,13 @@ func ExampleSplunk() {
 		{
 			Event:      "action=foo",
 			Index:      "events",
-			Source:     "main",
+			Source:     "app",
 			SourceType: "http",
 		},
 		{
 			Event:      "action=bar",
 			Index:      "events",
-			Source:     "main",
+			Source:     "app",
 			SourceType: "http",
 		},
 	}
@@ -28,6 +29,7 @@ func ExampleSplunk() {
 		mocksplunk.WithLicense(true),
 		mocksplunk.WithPassword("12345678"),
 		mocksplunk.WithValues(events),
+		mocksplunk.WithInitTimeout(time.Second),
 	)
 
 	// created container now includes two events in "events" index


### PR DESCRIPTION
When multiple events are ingested, container is released to the wild
before the events are indexed by splunk, causing bugs when querying it.
Now init function will wait for the events to get processed, and only
then it will release the container.

Fixes #1 